### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/totalcoop002/f0e891a6-a7bf-4158-a2db-9f3ee15f3ffc/7565f296-43b3-4377-8093-243d89172823/_apis/work/boardbadge/24a3a3d4-60b6-4aec-ba94-2cd5dd4e5b16)](https://dev.azure.com/totalcoop002/f0e891a6-a7bf-4158-a2db-9f3ee15f3ffc/_boards/board/t/7565f296-43b3-4377-8093-243d89172823/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/totalcoop002/f0e891a6-a7bf-4158-a2db-9f3ee15f3ffc/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.